### PR TITLE
Add Support for index-version Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ influxdb_data_cache_snapshot_write_cold_duration: "10m"
 influxdb_data_compact_full_write_cold_duration: "4h"
 influxdb_data_max_series_per_database: 1000000
 influxdb_data_max_values_per_tag: 100000
+influxdb_index_version: "inmem"
 
 # [coordinator]
 influxdb_coordinator_write_timeout: "10s"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,6 +45,7 @@ influxdb_data_cache_snapshot_write_cold_duration: "10m"
 influxdb_data_compact_full_write_cold_duration: "4h"
 influxdb_data_max_series_per_database: 1000000
 influxdb_data_max_values_per_tag: 100000
+influxdb_index_version: "inmem"
 
 # [coordinator]
 influxdb_coordinator_write_timeout: "10s"

--- a/templates/conf.j2
+++ b/templates/conf.j2
@@ -101,6 +101,10 @@ hostname = "{{ influxdb_hostname }}"
   # max-values-per-tag = 100000
   max-values-per-tag = {{ influxdb_data_max_values_per_tag }}
 
+  # The type of shard index to use for new shards. The default (inmem) index is an in-memory index that is recreated at startup.
+  # To enable the Time Series Index (TSI) disk-based index, set the value to tsi1.
+  index-version = {{ influxdb_index_version }}
+
 ###
 ### [coordinator]
 ###


### PR DESCRIPTION
Add support for the index-version data config that allows for toggling
between an in-memory index ("inmem") or Time Series Index ("tsi1")
introduced in InfluxDB v1.3.

https://www.influxdata.com/blog/path-1-billion-time-series-influxdb-high-cardinality-indexing-ready-testing/