### PR TITLE
Changes How Updated Templates are Checked

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,7 +59,7 @@
   command: "{{ influxdb_influxd_bin }} config -config {{ influxdb_generated_config }}"
   register: influxdb_merged_config
   become: yes
-  when: write_config | changed
+  when: write_config.changed
   tags:
     - influxdb
 
@@ -69,7 +69,7 @@
     dest: "{{ influxdb_config_file }}"
     group: "{{ influxdb_group }}"
     owner: "{{ influxdb_user }}"
-  when: influxdb_merged_config | changed
+  when: influxdb_merged_config.changed
   tags:
     - influxdb
 


### PR DESCRIPTION
Change the method used to check whether the configuration templates to
be copied over have changed since the most recent versions of Ansible
don't support the 'changed' filter (tested using Ansible 2.10).

Effort: 0:10 hours

Signed-off-by: Jason Rogena <jason@rogena.me>
